### PR TITLE
Make use of `espflash` tool

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,8 @@ jobs:
         rust:
           - stable
           - beta
-          - nightly
+          #- nightly due to a bug in compiler-builtins, the nightly builds
+          # currently fail -> ignore until upstream bug is fixed
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,6 @@ default=[]
 
 [workspace]
 members = ["examples/*"]
+
+[package.metadata.espflash]
+format = "direct-boot"

--- a/README.md
+++ b/README.md
@@ -38,31 +38,25 @@ The ESP32-C3 is based on the RISCV architecture. To build code for this architec
 rustup target add riscv32imc-unknown-none-elf
 ```
 
-Next, build one of the examples:
-
+Next, install the [`espflash`](https://github.com/esp-rs/espflash) tool that will take care of building and flashing the examples (and future applications based on `esp32c3-hal`):
 ```bash
-cargo build --example empty
+cargo install cargo-espflash
 ```
 
-The file was compiled into an elf file, more specifically a `ELF 32-bit LSB executable, UCB RISC-V, RVC, soft-float ABI, version 1 (SYSV), statically linked`. Next, it needs to be converted into a binary file that can be flashed:
-
+Use the following command to build and flash an example application to a connected ESP32-C3 board:
 ```bash
-riscv32-elf-objcopy -O binary ./target/riscv32imc-unknown-none-elf/debug/examples/empty empty.bin
+cargo espflash --package hello-world-demo /dev/tty.usbserial-10
 ```
-
-Finally, that file can be flashed onto the ESP32-C3 (the port may vary):
-
-```bash
-esptool.py --port /dev/ttyUSB0 --chip esp32c3 write_flash --flash_mode dio --flash_size detect --flash_freq 80m 0x0 empty.bin
-```
+Update the port (last argument) depending on your host system.
 
 ## Examples
 
-The HAL comes with a number of examples:
-- `empty.rs`: Start and enter an endless loop. This is to demonstrate that all relevant watchdogs can be disabled and the SoC does not continuously reset.
-- `hello_world.rs`: Write "Hello World" to UART0 (with the default pins) every second.
-- `uart_loopback.rs`: Read from UART0 and write back to UART0.
-- `blinky.rs`: Toggle a LED that is connected to GPIO2 every second.
+The HAL [cargo workspace](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html) currently comes with the following example packages (to be built/flashed using the `--package` option)
+- `blinky-demo`: Toggle a LED that is connected to GPIO2 every second.
+- `empty-demo`: Start and enter an endless loop. This is to demonstrate that all relevant watchdogs can be disabled and the SoC does not continuously reset.
+- `hello-world-demo`: Write "Hello World" to UART0 (with the default pins) every second.
+- `i2c-display-demo`: Display text on an monochrome OLED with a SSD1306 driver IC (via I2C).
+- `uart-loopback-demo`: Read from UART0 and write back to UART0.
 
 ## MSRV
 
@@ -87,4 +81,4 @@ for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 
 ## Resources
-- [Technical Reference Manual v0.3](https://www.espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf)
+- [Technical Reference Manual](https://www.espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf)


### PR DESCRIPTION
Make use of [`espflash`](https://github.com/esp-rs/espflash) for building and flashing binaries:
- Add package metadata
- Update README

Depends on the support of the `--package` support in the `espflash` tool that is currently an open PR there (https://github.com/esp-rs/espflash/pull/96).